### PR TITLE
New Parameter QoL additions

### DIFF
--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using UnhollowerRuntimeLib.XrefScans;
-using UnityEngine;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
 using MethodInfo = System.Reflection.MethodInfo;
@@ -39,9 +38,9 @@ namespace ParamLib
             ?.prop_VRCAvatarManager_0?.prop_VRCAvatarDescriptor_0?.expressionParameters
             ?.parameters;
 
-        public static VRCExpressionParameters.Parameter[] GetParams(VRCPlayer player) => player.transform
-            .Find("ForwardDirection").Find("Avatar").gameObject.GetComponent<VRCAvatarDescriptor>().expressionParameters
-            .parameters;
+        public static VRCExpressionParameters.Parameter[] GetParams(VRCPlayer player) => player.prop_VRCAvatarManager_0
+            ?.prop_VRCAvatarDescriptor_0?.expressionParameters
+            ?.parameters;
 
         public static bool DoesParamExist(string paramName, VRCExpressionParameters.ValueType paramType,
             VRCExpressionParameters.Parameter[] parameters = null)

--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -50,7 +50,7 @@ namespace ParamLib
             return _parameters.parameters;
         }
 
-        public bool DoesParamExist(string paramName, VRCExpressionParameters.ValueType paramType,
+        public static bool DoesParamExist(string paramName, VRCExpressionParameters.ValueType paramType,
             VRCExpressionParameters.Parameter[] parameters = new []{})
         {
             // If they're the default value, then assume Local Params

--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using UnhollowerRuntimeLib.XrefScans;
-using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
 using MethodInfo = System.Reflection.MethodInfo;
 
@@ -33,10 +32,9 @@ namespace ParamLib
 
             PrioritizeMethod.Invoke(LocalPlayableController, new object[] { paramIndex });
         }
-        
-        public static VRCExpressionParameters.Parameter[] GetLocalParams() => VRCPlayer.field_Internal_Static_VRCPlayer_0
-            ?.prop_VRCAvatarManager_0?.prop_VRCAvatarDescriptor_0?.expressionParameters
-            ?.parameters;
+
+        public static VRCExpressionParameters.Parameter[] GetLocalParams() =>
+            GetParams(VRCPlayer.field_Internal_Static_VRCPlayer_0);
 
         public static VRCExpressionParameters.Parameter[] GetParams(VRCPlayer player) => player.prop_VRCAvatarManager_0
             ?.prop_VRCAvatarDescriptor_0?.expressionParameters
@@ -48,21 +46,9 @@ namespace ParamLib
             // If they're null, then try getting LocalParams
             if(parameters == null)
                 parameters = GetLocalParams();
-            // If they're still null, then just return null
-            if (parameters == null)
-                return false;
+
             // Separate Length from nulll check, otherwise you'll get a null exception if parameters are null
-            if (parameters.Length == 0)
-                return false;
-
-            bool exists = false;
-            for (int i = 0; i < parameters.Length; i++)
-                if (!exists)
-                {
-                    exists = parameters[i].name == paramName && parameters[i].valueType == paramType;
-                }
-
-            return exists;
+            return parameters != null && parameters.Any(p => p.name == paramName && p.valueType == paramType);
         }
         
         public static (int?, VRCExpressionParameters.Parameter) FindParam(string paramName, VRCExpressionParameters.ValueType paramType,
@@ -71,12 +57,6 @@ namespace ParamLib
             // If they're null, then try getting LocalParams
             if(parameters == null)
                 parameters = GetLocalParams();
-            // If they're still null, then just return null
-            if (parameters == null)
-                return (null, null);
-            // Separate Length from null check, otherwise you'll get a null exception if parameters are null
-            if (parameters.Length == 0)
-                return (null, null);
 
             for (var i = 0; i < parameters.Length; i++)
             {

--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -51,12 +51,12 @@ namespace ParamLib
         }
 
         public static bool DoesParamExist(string paramName, VRCExpressionParameters.ValueType paramType,
-            VRCExpressionParameters.Parameter[] parameters = new []{})
+            VRCExpressionParameters.Parameter[] parameters = null)
         {
-            // If they're the default value, then assume Local Params
-            if(parameters == parameters == new []{})
+            // If they're null, then try getting LocalParams
+            if(parameters == null)
                 parameters = GetLocalParams();
-            // If they're null, then just return null
+            // If they're still null, then just return null
             if (parameters == null)
                 return (null, null);
             // Separate Length from nulll check, otherwise you'll get a null exception if parameters are null
@@ -74,12 +74,12 @@ namespace ParamLib
         }
         
         public static (int?, VRCExpressionParameters.Parameter) FindParam(string paramName, VRCExpressionParameters.ValueType paramType,
-            VRCExpressionParameters.Parameter[] parameters = new []{})
+            VRCExpressionParameters.Parameter[] parameters = null)
         {
-            // If they're the default value, then assume Local Params
-            if(parameters == parameters == new []{})
+            // If they're null, then try getting LocalParams
+            if(parameters == null)
                 parameters = GetLocalParams();
-            // If they're null, then just return null
+            // If they're still null, then just return null
             if (parameters == null)
                 return (null, null);
             // Separate Length from nulll check, otherwise you'll get a null exception if parameters are null

--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -38,17 +38,9 @@ namespace ParamLib
             ?.prop_VRCAvatarManager_0?.prop_VRCAvatarDescriptor_0?.expressionParameters
             ?.parameters;
 
-        public static VRCExpressionParameters.Parameter[] GetParams(VRCPlayer player)
-        {
-            // Get the Avatar
-            GameObject _avatar = player.transform.Find("ForwardDirection").Find("Avatar").gameObject;
-            // Get the Avatar Descriptor / easy method ;)
-            VRCAvatarDescriptor _descriptor = _avatar.GetComponent<VRCAvatarDescriptor>();
-            // Get the Expression Parameters
-            VRCExpressionParameters _parameters = _descriptor.expressionParameters;
-            // Return the list
-            return _parameters.parameters;
-        }
+        public static VRCExpressionParameters.Parameter[] GetParams(VRCPlayer player) => player.transform
+            .Find("ForwardDirection").Find("Avatar").gameObject.GetComponent<VRCAvatarDescriptor>().expressionParameters
+            .parameters;
 
         public static bool DoesParamExist(string paramName, VRCExpressionParameters.ValueType paramType,
             VRCExpressionParameters.Parameter[] parameters = null)
@@ -58,10 +50,10 @@ namespace ParamLib
                 parameters = GetLocalParams();
             // If they're still null, then just return null
             if (parameters == null)
-                return (null, null);
+                return false;
             // Separate Length from nulll check, otherwise you'll get a null exception if parameters are null
             if (parameters.Length == 0)
-                return (null, null);
+                return false;
 
             bool exists = false;
             for (int i = 0; i < parameters.Length; i++)

--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using UnhollowerRuntimeLib.XrefScans;
+using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
 using MethodInfo = System.Reflection.MethodInfo;
 
@@ -36,12 +37,53 @@ namespace ParamLib
         public static VRCExpressionParameters.Parameter[] GetLocalParams() => VRCPlayer.field_Internal_Static_VRCPlayer_0
             ?.prop_VRCAvatarManager_0?.prop_VRCAvatarDescriptor_0?.expressionParameters
             ?.parameters;
-        
-        public static (int?, VRCExpressionParameters.Parameter) FindParam(string paramName, VRCExpressionParameters.ValueType paramType)
-        {
-            var parameters = GetLocalParams();
 
+        public static VRCExpressionParameters.Parameter[] GetParams(VRCPlayer player)
+        {
+            // Get the Avatar
+            GameObject _avatar = player.transform.Find("ForwardDirection").Find("Avatar").gameObject;
+            // Get the Avatar Descriptor / easy method ;)
+            VRCAvatarDescriptor _descriptor = _avatar.GetComponent<VRCAvatarDescriptor>();
+            // Get the Expression Parameters
+            VRCExpressionParameters _parameters = _descriptor.expressionParameters;
+            // Return the list
+            return _parameters.parameters;
+        }
+
+        public bool DoesParamExist(string paramName, VRCExpressionParameters.ValueType paramType,
+            VRCExpressionParameters.Parameter[] parameters = new []{})
+        {
+            // If they're the default value, then assume Local Params
+            if(parameters == parameters == new []{})
+                parameters = GetLocalParams();
+            // If they're null, then just return null
             if (parameters == null)
+                return (null, null);
+            // Separate Length from nulll check, otherwise you'll get a null exception if parameters are null
+            if (parameters.Length == 0)
+                return (null, null);
+
+            bool exists = false;
+            for (int i = 0; i < parameters.Length; i++)
+                if (!exists)
+                {
+                    exists = parameters[i].name == paramName && parameters[i].valueType == paramType;
+                }
+
+            return exists;
+        }
+        
+        public static (int?, VRCExpressionParameters.Parameter) FindParam(string paramName, VRCExpressionParameters.ValueType paramType,
+            VRCExpressionParameters.Parameter[] parameters = new []{})
+        {
+            // If they're the default value, then assume Local Params
+            if(parameters == parameters == new []{})
+                parameters = GetLocalParams();
+            // If they're null, then just return null
+            if (parameters == null)
+                return (null, null);
+            // Separate Length from nulll check, otherwise you'll get a null exception if parameters are null
+            if (parameters.Length == 0)
                 return (null, null);
 
             for (var i = 0; i < parameters.Length; i++)

--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using UnhollowerRuntimeLib.XrefScans;
+using UnityEngine;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
 using MethodInfo = System.Reflection.MethodInfo;

--- a/ParamLib.cs
+++ b/ParamLib.cs
@@ -82,7 +82,7 @@ namespace ParamLib
             // If they're still null, then just return null
             if (parameters == null)
                 return (null, null);
-            // Separate Length from nulll check, otherwise you'll get a null exception if parameters are null
+            // Separate Length from null check, otherwise you'll get a null exception if parameters are null
             if (parameters.Length == 0)
                 return (null, null);
 


### PR DESCRIPTION
This PR introduces two new features in the ParamLib.cs file which can make developing with ParamLib easier and add new features for developers to make their mod even cooler!

Additions:

**bool DoesParamExist(string paramName, VRCExpressionParameters.ValueType paramType, VRCExpressionParameters.Parameter[] parameters = null)**

Checks to see if a parameter with the same type and name exist in a list of parameters and returns the according bool value. If `parameters` is left null, then the method assumes the local user's avatar's parameters.

**VRCExpressionParameters.Parameter[] GetParams(VRCPlayer player)**

Gets a list of a user's avatar's expression parameters. This introduces getting a list of parameters from *not* the local user's avatar. An example use case could be a mod displaying certain parameter's above the user's nameplate (like a heartrate maybe? 👀 )

Changes:

**(int?, VRCExpressionParameters.Parameter) FindParam(string paramName, VRCExpressionParameters.ValueType paramType, VRCExpressionParameters.Parameter[] parameters = null)**

Adapted to Find a Parameter from a specified list of VRCExpressionParameters, rather than just assuming a local user's avatar's parameters.

Let me know if there's any changes that need to happen, and I'll do my best, happy reviewing my (hopefully good) code!